### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,16 +13,16 @@ SensirionESS	KEYWORD1
 #######################################
 
 initSensors	KEYWORD2
-measureRHT KEYWORD2
-measureIAQ KEYWORD2
+measureRHT	KEYWORD2
+measureIAQ	KEYWORD2
 isInitialized	KEYWORD2
-getTemperature KEYWORD2
+getTemperature	KEYWORD2
 getHumidity	KEYWORD2
-getProductType KEYWORD2
-getFeatureSetVersion KEYWORD2
+getProductType	KEYWORD2
+getFeatureSetVersion	KEYWORD2
 getTVOC	KEYWORD2
 getECO2	KEYWORD2
-getError KEYWORD2
+getError	KEYWORD2
 setLedRYG	KEYWORD2
 remainingWaitTimeMS	KEYWORD2
 
@@ -33,9 +33,9 @@ remainingWaitTimeMS	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
-LED_RED LITERAL1
-LED_YEL LITERAL1
-LED_GRN LITERAL1
+LED_RED	LITERAL1
+LED_YEL	LITERAL1
+LED_GRN	LITERAL1
 
-PRODUCT_TYPE_SGP30 LITERAL1
-PRODUCT_TYPE_SGPC3 LITERAL1
+PRODUCT_TYPE_SGP30	LITERAL1
+PRODUCT_TYPE_SGPC3	LITERAL1


### PR DESCRIPTION
The Arduino IDE currently requires the use of a single true tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords