### PR TITLE
Bugfix iaq overflow

### DIFF
--- a/sensirion_ess.cpp
+++ b/sensirion_ess.cpp
@@ -160,14 +160,14 @@ int SensirionESS::measureIAQ()
 
     // SGPC3 only has TVOC; SGP30 sends [eco2, tvoc]
     if (mProductType == PRODUCT_TYPE_SGP30) {
-      mECO2 = (mDataBuf[0] << 8) | mDataBuf[1];
+      mECO2 = (uint16_t)(mDataBuf[0] << 8) | mDataBuf[1];
       if (crc8(mDataBuf+3, 2) != mDataBuf[5]) {
           setError("CRC mismatch");
           return -4;
       }
-      mTVOC = (mDataBuf[3] << 8) | mDataBuf[4];
+      mTVOC = (uint16_t)(mDataBuf[3] << 8) | mDataBuf[4];
   } else {
-      mTVOC = (mDataBuf[0] << 8) | mDataBuf[1];;
+      mTVOC = (uint16_t)(mDataBuf[0] << 8) | mDataBuf[1];;
   }
 
     return 0;
@@ -245,12 +245,12 @@ float SensirionESS::getHumidity() const
     return mHumidity;
 }
 
-float SensirionESS::getTVOC() const
+uint16_t SensirionESS::getTVOC() const
 {
     return mTVOC;
 }
 
-float SensirionESS::getECO2() const
+uint16_t SensirionESS::getECO2() const
 {
     return mECO2;
 }

--- a/sensirion_ess.cpp
+++ b/sensirion_ess.cpp
@@ -167,7 +167,7 @@ int SensirionESS::measureIAQ()
       }
       mTVOC = (uint16_t)(mDataBuf[3] << 8) | mDataBuf[4];
   } else {
-      mTVOC = (uint16_t)(mDataBuf[0] << 8) | mDataBuf[1];;
+      mTVOC = (uint16_t)(mDataBuf[0] << 8) | mDataBuf[1];
   }
 
     return 0;

--- a/sensirion_ess.h
+++ b/sensirion_ess.h
@@ -51,8 +51,8 @@ public:
     int getProductType() const;
     int getFeatureSetVersion() const;
 
-    float getTVOC() const;
-    float getECO2() const; // SGP30 only
+    uint16_t getTVOC() const;
+    uint16_t getECO2() const; // SGP30 only
 
     const char* getError() const;
 
@@ -101,8 +101,8 @@ private:
 
     float mTemperature = -250;
     float mHumidity    = -1;
-    float mTVOC        = -1;
-    float mECO2        = -1;
+    uint16_t mTVOC        = 0;
+    uint16_t mECO2        = 0;
 
     int mProductType       = 0;
     int mFeatureSetVersion = 0;


### PR DESCRIPTION
before this change, TVOC and CO2eq were defined as float; max resolution is 1pp{p,m}, so making this a float didn't make sense. Additionally, the two values would overflow