### PR TITLE
Extract LED handling from ESS main class

### DIFF
--- a/examples/ess-human-presence-detector/ess-human-presence-detector.ino
+++ b/examples/ess-human-presence-detector/ess-human-presence-detector.ino
@@ -30,7 +30,7 @@ void setup()
       delay(1000); // wait forever
     }
   }
-  digitalWrite(SensirionESS::LED_YEL, HIGH);
+  digitalWrite(SensirionESSLeds::ARDUINO_UNO_LED_YEL_PIN, HIGH);
 }
 
 void loop() {
@@ -46,13 +46,13 @@ void loop() {
 
   if (measurementCount > SGP_WARMUP_COUNT) {
     if (ess.getECO2() > eco2_threshold) {
-      digitalWrite(SensirionESS::LED_RED, HIGH);
+      digitalWrite(SensirionESSLeds::ARDUINO_UNO_LED_RED_PIN, HIGH);
     } else {
-      digitalWrite(SensirionESS::LED_RED, LOW);
+      digitalWrite(SensirionESSLeds::ARDUINO_UNO_LED_RED_PIN, LOW);
     }
   } else {
     if (measurementCount == SGP_WARMUP_COUNT) {
-      digitalWrite(SensirionESS::LED_YEL, LOW);
+      digitalWrite(SensirionESSLeds::ARDUINO_UNO_LED_YEL_PIN, LOW);
       eco2_threshold = ess.getECO2() * 1.2;
 
       Serial.print("Threshold set at: ");

--- a/examples/led-demo/led-demo.ino
+++ b/examples/led-demo/led-demo.ino
@@ -1,6 +1,20 @@
+// This example shows how to control the LEDs on the ESS
+//
+// *Important*: this is configured for boards following the Arduino Uno footprint.
+// If your board has a different layout - e.g. ESP8266, ESP32, SAMD21 - please
+// configure LED pins to match your layout!
+
 #include <sensirion_ess.h>
 
-SensirionESS ess;
+// This is configured for Arduino Uno based boards; if you have a different board,
+// please adapt the pins to match your setup
+#define LED_RED SensirionESSLeds::ARDUINO_UNO_LED_RED_PIN
+#define LED_YEL SensirionESSLeds::ARDUINO_UNO_LED_YEL_PIN
+#define LED_GRN SensirionESSLeds::ARDUINO_UNO_LED_GRN_PIN
+
+SensirionESSLeds essLeds(LED_RED,
+                         LED_YEL,
+                         LED_GRN);
 
 int repetitions  =    3;
 int fadeDelay    =    5;
@@ -9,48 +23,46 @@ int sectionDelay = 1000;
 
 void setup()
 {
-  // this is needed to set the pinModes
-  ess.initSensors();
 }
 
 void loop()
 {
-  // -- Sensirion::setLedRYG()
+  // -- SensirionESSLeds::setLedRYG()
   for (int i = 0; i < repetitions; ++i) {
-    ess.setLedRYG(1, 0, 0); delay(stepDelay);
-    ess.setLedRYG(0, 1, 0); delay(stepDelay);
-    ess.setLedRYG(0, 0, 1); delay(stepDelay);
+    essLeds.setLedRYG(1, 0, 0); delay(stepDelay);
+    essLeds.setLedRYG(0, 1, 0); delay(stepDelay);
+    essLeds.setLedRYG(0, 0, 1); delay(stepDelay);
   }
-  ess.setLedRYG(0, 0, 0);
+  essLeds.setLedRYG(0, 0, 0);
   delay(sectionDelay);
 
   // -- manual access
   for (int i = 0; i < repetitions; ++i) {
-    digitalWrite(SensirionESS::LED_RED, HIGH); delay(stepDelay);
-    digitalWrite(SensirionESS::LED_YEL, HIGH); delay(stepDelay);
-    digitalWrite(SensirionESS::LED_GRN, HIGH); delay(stepDelay);
-    digitalWrite(SensirionESS::LED_RED,  LOW); delay(stepDelay);
-    digitalWrite(SensirionESS::LED_YEL,  LOW); delay(stepDelay);
-    digitalWrite(SensirionESS::LED_GRN,  LOW); delay(stepDelay);
+    digitalWrite(LED_RED, HIGH); delay(stepDelay);
+    digitalWrite(LED_YEL, HIGH); delay(stepDelay);
+    digitalWrite(LED_GRN, HIGH); delay(stepDelay);
+    digitalWrite(LED_RED,  LOW); delay(stepDelay);
+    digitalWrite(LED_YEL,  LOW); delay(stepDelay);
+    digitalWrite(LED_GRN,  LOW); delay(stepDelay);
   }
-  ess.setLedRYG(0, 0, 0);
+  essLeds.setLedRYG(0, 0, 0);
   delay(sectionDelay);
 
   // -- analogWrite() - requires pins 9-11 to be PWM pins
   for (int i = 0; i < repetitions; ++i) {
     for (int j = 0; j < 255; ++j) {
-      analogWrite(SensirionESS::LED_RED, j);
-      analogWrite(SensirionESS::LED_YEL, j);
-      analogWrite(SensirionESS::LED_GRN, j);
+      analogWrite(LED_RED, j);
+      analogWrite(LED_YEL, j);
+      analogWrite(LED_GRN, j);
       delay(fadeDelay);
     }
     for (int j = 255; j >= 0; --j) {
-      analogWrite(SensirionESS::LED_RED, j);
-      analogWrite(SensirionESS::LED_YEL, j);
-      analogWrite(SensirionESS::LED_GRN, j);
+      analogWrite(LED_RED, j);
+      analogWrite(LED_YEL, j);
+      analogWrite(LED_GRN, j);
       delay(fadeDelay);
     }
   }
-  ess.setLedRYG(0, 0, 0);
+  essLeds.setLedRYG(0, 0, 0);
   delay(sectionDelay);
 }

--- a/keywords.txt
+++ b/keywords.txt
@@ -7,6 +7,7 @@
 #######################################
 
 SensirionESS	KEYWORD1
+SensirionESSLeds KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -33,9 +34,9 @@ remainingWaitTimeMS	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
-LED_RED	LITERAL1
-LED_YEL	LITERAL1
-LED_GRN	LITERAL1
+ARDUINO_UNO_LED_RED_PIN	LITERAL1
+ARDUINO_UNO_LED_YEL_PIN	LITERAL1
+ARDUINO_UNO_LED_GRN_PIN	LITERAL1
 
 PRODUCT_TYPE_SGP30	LITERAL1
 PRODUCT_TYPE_SGPC3	LITERAL1

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=arduino-ess
-version=0.5.3
+version=0.5.4
 author=Johannes Winkelmann
 maintainer=Johannes Winkelmann <jwi@sensirion.com>
 sentence=Support for Sensirion's Environmental Sensor Shield

--- a/sensirion_ess.cpp
+++ b/sensirion_ess.cpp
@@ -42,14 +42,20 @@
 
 #include "sensirion_ess.h"
 
-/*
- * GPIOs for the LEDS are based around a standard Arduino footprint
- * Let's enable them by default, unless we know we're on an unsupported
- * platform
- */
-#if !defined(ESP8266)
-#define ENABLE_LED_SUPPORT
-#endif /* ESP8266 */
+SensirionESSLeds::SensirionESSLeds(int redLedPin, int yellowLedPin, int greenLedPin)
+    : mRedLedPin(redLedPin), mYellowLedPin(yellowLedPin), mGreenLedPin(greenLedPin)
+{
+    pinMode(mRedLedPin, OUTPUT);
+    pinMode(mYellowLedPin, OUTPUT);
+    pinMode(mGreenLedPin, OUTPUT);
+}
+
+void SensirionESSLeds::setLedRYG(int r, int y, int g)
+{
+    digitalWrite(mRedLedPin,    r ? HIGH : LOW);
+    digitalWrite(mYellowLedPin, y ? HIGH : LOW);
+    digitalWrite(mGreenLedPin,  g ? HIGH : LOW);
+}
 
 
 SensirionESS::SensirionESS()
@@ -70,11 +76,7 @@ int SensirionESS::initSensors()
         return -2;
     }
 
-#ifdef ENABLE_LED_SUPPORT
-    pinMode(LED_RED, OUTPUT);
-    pinMode(LED_YEL, OUTPUT);
-    pinMode(LED_GRN, OUTPUT);
-#endif /* ENABLE_LED_SUPPORT */
+
 
     mInitialized = true;
     return 0;
@@ -265,15 +267,6 @@ uint16_t SensirionESS::getTVOC() const
 uint16_t SensirionESS::getECO2() const
 {
     return mECO2;
-}
-
-void SensirionESS::setLedRYG(int r, int y, int g)
-{
-#ifdef ENABLE_LED_SUPPORT
-    digitalWrite(LED_RED, r ? HIGH : LOW);
-    digitalWrite(LED_YEL, y ? HIGH : LOW);
-    digitalWrite(LED_GRN, g ? HIGH : LOW);
-#endif /* #ifdef ENABLE_LED_SUPPORT */
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/sensirion_ess.h
+++ b/sensirion_ess.h
@@ -33,6 +33,25 @@
 
 #include <stdint.h>
 
+class SensirionESSLeds
+{
+public:
+    SensirionESSLeds(int redLedPin, int yellowLedPin, int greenLedPin);
+    void setLedRYG(int r, int y, int g);
+
+    const static int SGP_RED_THRESHOLD     = 150;
+    const static int SGP_YEL_THRESHOLD     = 125;
+
+    const static int ARDUINO_UNO_LED_RED_PIN   = 9;
+    const static int ARDUINO_UNO_LED_YEL_PIN   = 10;
+    const static int ARDUINO_UNO_LED_GRN_PIN   = 11;
+
+private:
+    int mRedLedPin    = -1;
+    int mYellowLedPin = -1;
+    int mGreenLedPin  = -1;
+};
+
 class SensirionESS
 {
 public:
@@ -56,13 +75,7 @@ public:
 
     const char* getError() const;
 
-    void setLedRYG(int r, int y, int g);
-
     int remainingWaitTimeMS();
-
-    const static int LED_RED                = 9;
-    const static int LED_YEL                = 10;
-    const static int LED_GRN                = 11;
 
     const static int PRODUCT_TYPE_SGP30    = 0;
     const static int PRODUCT_TYPE_SGPC3    = 1;
@@ -76,7 +89,6 @@ private:
     int readFeatureSetInt();
     int measureRHTInt();
     int initSGP();
-    void setLedRYGInt(int r, int y, int g);
 
     const static int ERROR_BUF_LENGTH       = 255;
     const static int CMD_LENGTH             = 2;
@@ -89,9 +101,6 @@ private:
     const static int SGPC3_DATA_LENGTH      = 3;
     const static int SGP_I2C_ADDR           = 0x58;
     const static int SGP_MEASURE_DELAY      = 50;
-
-    const static int SGP_RED_THRESHOLD     = 150;
-    const static int SGP_YEL_THRESHOLD     = 125;
 
     const static int SGPC3_INTERMEASURE_DELAY = 2000;
     const static int SGP30_INTERMEASURE_DELAY = 1000;


### PR DESCRIPTION
We originally added some LED handling the the ESS main class (SensirionESS)
with the goal to simplify interfacing with the onboard LEDs on the ESS.
While that seemed to be a good idea at the time, it really only works when
the ESS is used on a board that follows the Arduino Uno footprint. Many
other common Arduino-compatible boards have different pinouts, and some
of the LED pin settings can conflict with I2C ports (e.g. on ESP8266 or
MKR board).

This commit moves this into a separate class (SensirionEssLeds), renames
the constant for the Arduino Uno pins to include ARDUINO_UNO_ in their
name, and requires passing those pins in the constructor to force the
user to think about it while setting it up. This is a bit more code to
write, but since we provide a fairly complete example in 'led-demo' I
believe people can just copy this anyway.